### PR TITLE
Adding priviledge  to remove compose binary

### DIFF
--- a/lib/darwin/runner.sh
+++ b/lib/darwin/runner.sh
@@ -399,7 +399,7 @@ fi
 composeBinary=$(which docker-compose)
 if [ -f "$composeBinary" ]; then
     echo "Removing compose binary file"
-    rm "$composeBinary"
+    sudo rm "$composeBinary"
 fi 
 
 echo "Script finished..."


### PR DESCRIPTION
Removal without sudo didn't work for all pipelines, adding that. Related to and updating issues https://github.com/podman-desktop/podman-desktop/issues/8942 and https://github.com/podman-desktop/e2e/issues/314.