### PR TITLE
chore(e2e): add ROOTFUL_MODE envvar for kind tests

### DIFF
--- a/lib/windows/runner.ps1
+++ b/lib/windows/runner.ps1
@@ -101,6 +101,15 @@ function Load-Variables() {
     $global:scriptEnvVars += "CI"
     $global:envVarDefs += 'CI=true'
 
+    write-host "Setting default env. var.: ROOTFUL_MODE=0"
+    $rootfulMode='false'
+    if $rootful -eq '1' {
+        $rootfulMode='true'
+    }
+    Set-Item -Path "env:ROOTFUL_MODE" -Value $rootfulMode
+    $global:scriptEnvVars += "ROOTFUL_MODE"
+    $global:envVarDefs += "ROOTFUL_MODE=$rootfulMode"
+
     # Set PODMAN_DESKTOP_BINARY if exists
     if($podmanDesktopBinary) {
         Set-Item -Path "env:PODMAN_DESKTOP_BINARY" -Value "$podmanDesktopBinary"


### PR DESCRIPTION
Adds ROOTFUL_MODE envvar to be used for skipping the kind tests that run in rootless mode
Fixes [#315](https://github.com/podman-desktop/e2e/issues/315) partially