### PR TITLE
chore(e2e): added image size selection on windows setup script

### DIFF
--- a/lib/windows/scripts/stress_test_ui.ps1
+++ b/lib/windows/scripts/stress_test_ui.ps1
@@ -21,6 +21,10 @@ switch ($env:IMAGE_SIZE) {
     "large" {
         $testImage=$largeImage
     }
+    default {
+        Write-Host "IMAGE_SIZE '$env:IMAGE_SIZE' not found. Setting testImage to tinyImage"
+        $testImage=$tinyImage
+    }
 }
 
 # pull the image

--- a/lib/windows/scripts/stress_test_ui.ps1
+++ b/lib/windows/scripts/stress_test_ui.ps1
@@ -8,7 +8,20 @@ $smallImage="quay.io/sclorg/nginx-122-micro-c9s:20230718" # ~70MB
 $mediumImage="docker.io/library/nginx:latest" # ~200MB
 $largeImage="registry.access.redhat.com/ubi8/httpd-24-3:latest" # ~460MB
 
-$testImage=$tinyImage
+switch ($env:IMAGE_SIZE) {
+    "tiny" {
+        $testImage=$tinyImage
+    }
+    "small" {
+        $testImage=$smallImage
+    }
+    "medium" {
+        $testImage=$mediumImage
+    }
+    "large" {
+        $testImage=$largeImage
+    }
+}
 
 # pull the image
 Write-Host "Pulling image: $testImage"


### PR DESCRIPTION
Uses the `IMAGE_SIZE` env var from the `podman-desktop-e2e-stress-test-ui-windows` workflow to select the image size in the setup script