### PR TITLE
chore(ci): fix powershell  evaluating to 'True'

### DIFF
--- a/lib/windows/runner.ps1
+++ b/lib/windows/runner.ps1
@@ -102,7 +102,7 @@ function Load-Variables() {
     Write-Host "Input String: '$envVars'"
 
     write-host "Setting default env. var.: CI=true"
-    Set-Item -Path "env:CI" -Value $true
+    Set-Item -Path "env:CI" -Value "true"
     $global:scriptEnvVars += "CI"
     $global:envVarDefs += 'CI=true'
 


### PR DESCRIPTION
Closes https://github.com/containers/podman-desktop-extension-ai-lab/issues/3913

```
**********************************
* TEST CONFIGURATION INFORMATION *
**********************************

  AI Lab Extension OCI Image: ghcr.io/containers/podman-desktop-extension-ai-lab:nightly
  AI Lab Extension Preinstalled: false
  Test Audio File Path: C:\Users\rhqp\pd-e2e\podman-desktop-extension-ai-lab\tests\playwright\resources\test-audio-to-text.wav
  Playground Test Models: ibm-granite/granite-4.0-micro-GGUF
  AI App HTTP Tests: Object Detection
  AI App Service Response Tests: Audio to Text, Function calling

  Test RAG Chatbot Apps: false

  IS WINDOWS: true
  IS LINUX: false
  IS MAC: false
  IS CI: false | CI env variable: True

**********************************
```

<img width="700" height="200" alt="Screenshot_20251125_135347" src="https://github.com/user-attachments/assets/de0a41ff-d61a-4ef0-bc15-743359b7874c" />

`export const isCI = process.env.CI ? process.env.CI === 'true' : false;` expects `true`