### PR TITLE
test(e2e): script that fixes wsl dns issue

### DIFF
--- a/lib/windows/scripts/wsl_dns_update.ps1
+++ b/lib/windows/scripts/wsl_dns_update.ps1
@@ -1,3 +1,16 @@
+Write-Host "---Checking WSL availability---"
+$wslStatus = wsl --status 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "WSL is not enabled or not properly installed, skipping DNS fix"
+    exit 0
+}
+$distros = wsl --list --quiet 2>$null
+if (-not $distros) {
+    Write-Host "No WSL distributions installed, skipping DNS fix"
+    exit 0
+}
+Write-Host "WSL is available with distributions: $($distros -join ', ')"
+
 Write-Host "---Verifying if DNS resolution is working or not---"
 $result = wsl -e curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 https://ghcr.io 2>$null
 if ($result -match "^[23]\d{2}$") { # 200-299 = Success; 300-399 = Redirect

--- a/lib/windows/scripts/wsl_dns_update.ps1
+++ b/lib/windows/scripts/wsl_dns_update.ps1
@@ -6,12 +6,52 @@ if ($LASTEXITCODE -ne 0) {
     Write-Host "WSL is not enabled or not properly installed, skipping DNS fix"
     exit 0
 }
+
+Write-Host "---Setting up .wslconfig---"
+# Just in case the podman machine is re-created during tests or there is no machine to begin with
+# With dnsProxy=false, WSL will mirror the Windows DNS servers (8.8.8.8) to Linux
+$wslConfigPath = "$env:USERPROFILE\.wslconfig"
+$wslConfigContent = @"
+[wsl2]
+dnsProxy=false
+"@
+Set-Content -Path $wslConfigPath -Value $wslConfigContent -Force
+Write-Host ".wslconfig created at: $wslConfigPath"
+Get-Content $wslConfigPath
+
+Write-Host "---Verifying WSL distributions---"
 $distros = wsl --list --quiet 2>$null
 if (-not $distros) {
-    Write-Host "No WSL distributions installed, skipping DNS fix"
+    Write-Host "No WSL distributions installed, machine should be created during tests with .wslconfig settings"
     exit 0
+}else{
+    Write-Host "WSL is available with distributions: $($distros -join ', ')"
 }
-Write-Host "WSL is available with distributions: $($distros -join ', ')"
+
+Write-Host "---Making sure podman is the current WSL distribution---"
+# Get list of installed WSL distributions and filter for podman ones
+$podmanDistros = $distros | Where-Object { $_ -match "podman" }
+if ($podmanDistros) {
+    $podmanDistrosList = @($podmanDistros)
+    Write-Host "Found podman distributions: $($podmanDistrosList -join ', ')"
+    
+    # Check if podman-machine-default exists, otherwise use the first podman distro
+    if ($podmanDistrosList -contains "podman-machine-default") {
+        $targetDistro = "podman-machine-default"
+    } else {
+        $targetDistro = $podmanDistrosList[0]
+    }
+    
+    Write-Host "Setting default WSL distribution to: $targetDistro"
+    wsl --set-default $targetDistro
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "Successfully set $targetDistro as default WSL distribution"
+    } else {
+        Write-Host "Warning: Failed to set $targetDistro as default WSL distribution"
+    }
+} else {
+    Write-Host "No podman distributions found, skipping default distribution setup"
+}
 
 Write-Host "---Verifying if DNS resolution is working or not---"
 $result = wsl -e curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 https://ghcr.io 2>$null
@@ -37,23 +77,17 @@ wsl -e sudo cat /etc/resolv.conf
 Write-Host "---Setting Windows Host DNS to 8.8.8.8---"
 # Set DNS on all active network adapters so WSL can mirror it
 $adapters = Get-NetAdapter | Where-Object { $_.Status -eq "Up" }
+
+Write-Host "Current DNS configuration before changes:"
+Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object { $_.ServerAddresses } | Format-Table -AutoSize
+
 foreach ($adapter in $adapters) {
     Write-Host "Setting DNS for adapter: $($adapter.Name)"
     Set-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -ServerAddresses "8.8.8.8","8.8.4.4"
 }
-Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object { $_.ServerAddresses } | Format-Table -AutoSize
 
-Write-Host "---Setting up .wslconfig---"
-# Just in case the podman machine is re-created during tests
-# With dnsProxy=false, WSL will mirror the Windows DNS servers (8.8.8.8) to Linux
-$wslConfigPath = "$env:USERPROFILE\.wslconfig"
-$wslConfigContent = @"
-[wsl2]
-dnsProxy=false
-"@
-Set-Content -Path $wslConfigPath -Value $wslConfigContent -Force
-Write-Host ".wslconfig created at: $wslConfigPath"
-Get-Content $wslConfigPath
+Write-Host "DNS configuration after changes:"
+Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object { $_.ServerAddresses } | Format-Table -AutoSize
 
 Write-Host "---Restarting WSL to apply changes---"
 wsl --shutdown

--- a/lib/windows/scripts/wsl_dns_update.ps1
+++ b/lib/windows/scripts/wsl_dns_update.ps1
@@ -1,3 +1,5 @@
+# Addresses this unstability from Windows 10 Azure runners https://github.com/podman-desktop/podman-desktop/issues/14825
+
 Write-Host "---Checking WSL availability---"
 $wslStatus = wsl --status 2>&1
 if ($LASTEXITCODE -ne 0) {
@@ -31,6 +33,31 @@ Write-Host "---Specifying a more reliable DNS server---"
 wsl -e sudo rm -f /etc/resolv.conf 
 wsl -e sudo bash -c "echo 'nameserver 8.8.8.8' > /etc/resolv.conf" 
 wsl -e sudo cat /etc/resolv.conf 
+
+Write-Host "---Setting Windows Host DNS to 8.8.8.8---"
+# Set DNS on all active network adapters so WSL can mirror it
+$adapters = Get-NetAdapter | Where-Object { $_.Status -eq "Up" }
+foreach ($adapter in $adapters) {
+    Write-Host "Setting DNS for adapter: $($adapter.Name)"
+    Set-DnsClientServerAddress -InterfaceIndex $adapter.ifIndex -ServerAddresses "8.8.8.8","8.8.4.4"
+}
+Get-DnsClientServerAddress -AddressFamily IPv4 | Where-Object { $_.ServerAddresses } | Format-Table -AutoSize
+
+Write-Host "---Setting up .wslconfig---"
+# Just in case the podman machine is re-created during tests
+# With dnsProxy=false, WSL will mirror the Windows DNS servers (8.8.8.8) to Linux
+$wslConfigPath = "$env:USERPROFILE\.wslconfig"
+$wslConfigContent = @"
+[wsl2]
+dnsProxy=false
+"@
+Set-Content -Path $wslConfigPath -Value $wslConfigContent -Force
+Write-Host ".wslconfig created at: $wslConfigPath"
+Get-Content $wslConfigPath
+
+Write-Host "---Restarting WSL to apply changes---"
+wsl --shutdown
+Start-Sleep -Seconds 2
 
 Write-Host "---Verifying if DNS resolution is working after the applied fix---"
 $result = wsl -e curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 https://ghcr.io 2>$null

--- a/lib/windows/scripts/wsl_dns_update.ps1
+++ b/lib/windows/scripts/wsl_dns_update.ps1
@@ -1,21 +1,28 @@
-# verify DNS resolution is not working
-wsl curl -I https://ghcr.io 
+Write-Host "---Verifying if DNS resolution is working or not---"
+$result = wsl -e curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 https://ghcr.io 2>$null
+if ($result -match "^[23]\d{2}$") { # 200-299 = Success; 300-399 = Redirect
+    Write-Host "DNS resolution is working (HTTP $result), no fix needed"
+    exit 0
+}
+Write-Host "DNS resolution failed (HTTP $result), applying fix"
 
-# show current configuration status
-wsl sudo cat /etc/wsl.conf
+Write-Host "---Current configuration status---"
+wsl -e sudo cat /etc/wsl.conf
 
-# change default dns behavior
-wsl sudo sh -c 'cat <<EOT > /etc/wsl.conf  
-[network]   
-generateResolvConf = false 
-EOT' 
+Write-Host "---Changing default DNS behavior---"
+# appends a [network] entry if it doesn't exist already
+wsl -e sudo bash -c "grep -q '\[network\]' /etc/wsl.conf 2>/dev/null || printf '\n[network]\n' >> /etc/wsl.conf; grep -q 'generateResolvConf' /etc/wsl.conf || echo 'generateResolvConf = false' >> /etc/wsl.conf" 
+wsl -e sudo cat /etc/wsl.conf 
 
-# show configuration changes
-wsl sudo cat /etc/wsl.conf 
+Write-Host "---Specifying a more reliable DNS server---"
+wsl -e sudo rm -f /etc/resolv.conf 
+wsl -e sudo bash -c "echo 'nameserver 8.8.8.8' > /etc/resolv.conf" 
+wsl -e sudo cat /etc/resolv.conf 
 
-# specify a more reliable DNS server
-wsl sudo rm -f /etc/resolv.conf 
-wsl sudo sh -c 'echo "nameserver 8.8.8.8" > /etc/resolv.conf' 
-
-# verify DNS resolution should work now
-wsl curl -I https://ghcr.io 
+Write-Host "---Verifying if DNS resolution is working after the applied fix---"
+$result = wsl -e curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 https://ghcr.io 2>$null
+if ($result -match "^[23]\d{2}$") { # 200-299 = Success; 300-399 = Redirect
+    Write-Host "DNS resolution is working (HTTP $result), the fix worked"
+    exit 0
+}
+Write-Host "DNS resolution failed (HTTP $result), the fix did not work"

--- a/lib/windows/scripts/wsl_dns_update.ps1
+++ b/lib/windows/scripts/wsl_dns_update.ps1
@@ -1,0 +1,21 @@
+# verify DNS resolution is not working
+wsl curl -I https://ghcr.io 
+
+# show current configuration status
+wsl sudo cat /etc/wsl.conf
+
+# change default dns behavior
+wsl sudo sh -c 'cat <<EOT > /etc/wsl.conf  
+[network]   
+generateResolvConf = false 
+EOT' 
+
+# show configuration changes
+wsl sudo cat /etc/wsl.conf 
+
+# specify a more reliable DNS server
+wsl sudo rm -f /etc/resolv.conf 
+wsl sudo sh -c 'echo "nameserver 8.8.8.8" > /etc/resolv.conf' 
+
+# verify DNS resolution should work now
+wsl curl -I https://ghcr.io 


### PR DESCRIPTION
Adds a new script to be run on windows 10 wsl workflows so that the DNS used in the podman machine can resolve properly the pull of images

Related issue: https://github.com/podman-desktop/podman-desktop/issues/14825
Related PRs: 
- https://github.com/podman-desktop/podman-desktop/pull/15192
- https://github.com/podman-desktop/e2e/pull/538