### PR TITLE
chore: ensure consistent JUnit report naming across platforms

### DIFF
--- a/lib/darwin/runner.sh
+++ b/lib/darwin/runner.sh
@@ -197,14 +197,26 @@ function collect_logs() {
     local source="$workingDir/$folder"
     local target="$workingDir/$resultsFolder/$folder"
     echo "Collecting the results from: $source, to: " $target
-    # copy all junit xml files into target and rename them by the folder the were in
-    local junits=$(find $source -name "junit*.xml")
-    echo "Found Junit files: $junits"
-    for junit in $junits; do
+    
+    # Find all JUnit files
+    local -a junits
+    mapfile -t junits < <(find $source -name "junit*.xml")
+    local count=${#junits[@]}
+    
+    # Add the warning if accidental extras are found
+    if (( count > 1 )); then
+        echo "WARNING: Expected exactly one JUnit file, but found $count! Proceeding with the first one found."
+    fi
+    
+    # Grab the first one found
+    local junit="${junits[0]}"
+    
+    if [ -n "$junit" ]; then
+        echo "Found Junit file: $junit"
         target_path="$workingDir/$resultsFolder/junit-$folder.xml"
         echo "Copying $junit and renaming to $target_path"
         cp "$junit" $target_path
-    done
+    fi
     if (( extTests == 1 )); then
         echo "Removing possible models from working directories"
         ls $source/**/output/**/*.gguf

--- a/lib/darwin/runner.sh
+++ b/lib/darwin/runner.sh
@@ -216,7 +216,10 @@ function collect_logs() {
         target_path="$workingDir/$resultsFolder/junit-$folder.xml"
         echo "Copying $junit and renaming to $target_path"
         cp "$junit" $target_path
+    else
+        echo "WARNING: No JUnit file found in $source"
     fi
+
     if (( extTests == 1 )); then
         echo "Removing possible models from working directories"
         ls $source/**/output/**/*.gguf

--- a/lib/windows/runner.ps1
+++ b/lib/windows/runner.ps1
@@ -242,6 +242,8 @@ function Collect-Logs($folder) {
         $target_path = "$workingDir\$resultsFolder\junit-$folder.xml"
         write-host "Copying $($junit.FullName) and renaming to $target_path"
         Copy-Item -Path $junit.FullName -Destination $target_path -Force
+    } else {
+        write-host "WARNING: No JUnit file found in $source"
     }
 
     if ($extTests -eq "1") {

--- a/lib/windows/runner.ps1
+++ b/lib/windows/runner.ps1
@@ -225,6 +225,25 @@ function Collect-Logs($folder) {
     $source="$workingDir\$folder"
     $target="$workingDir\$resultsFolder\$folder"
     write-host "Collecting the results from: $source, to: $target"
+
+    # Find all JUnit files safely and force result into an array
+    $junits = @(Get-ChildItem -Path $source -Filter "junit*.xml" -Recurse)
+    $count = $junits.Count
+
+    # Add the warning if accidental extras are found
+    if ($count -gt 1) {
+        write-host "WARNING: Expected exactly one JUnit file, but found $count! Proceeding with the first one found."
+    }
+
+    # Grab the first one found
+    if ($count -gt 0) {
+        $junit = $junits[0]
+        write-host "Found Junit file: $($junit.FullName)"
+        $target_path = "$workingDir\$resultsFolder\junit-$folder.xml"
+        write-host "Copying $($junit.FullName) and renaming to $target_path"
+        Copy-Item -Path $junit.FullName -Destination $target_path -Force
+    }
+
     if ($extTests -eq "1") {
         write-host "Removing possible models from working directories"
         Get-ChildItem -Path "$source" -Name "*.gguf" -Recurse | Remove-Item -Force


### PR DESCRIPTION
Fixes partially: https://github.com/podman-desktop/e2e/issues/557